### PR TITLE
fix: reflect physical smarthub state changes in HA via OOB notifications

### DIFF
--- a/custom_components/inlite/__init__.py
+++ b/custom_components/inlite/__init__.py
@@ -65,8 +65,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: InliteConfigEntry) -> bo
     # Disconnect hubs when the config entry is unloaded
     entry.async_on_unload(coordinator.async_shutdown)
 
+    # Reload integration when options change (scan interval, idle disconnect)
+    entry.async_on_unload(entry.add_update_listener(_async_options_updated))
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def _async_options_updated(
+    hass: HomeAssistant, entry: InliteConfigEntry
+) -> None:
+    """Reload when options are updated."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: InliteConfigEntry) -> bool:

--- a/custom_components/inlite/config_flow.py
+++ b/custom_components/inlite/config_flow.py
@@ -4,6 +4,7 @@ Supports three entry points:
 - User-initiated: email → code → select garden
 - Bluetooth discovery: HA finds "inlitebt" → user confirms → email flow
 - Reauth: re-run email/code flow to update credentials
+- Options: configure scan interval and idle disconnect timeout
 """
 
 from __future__ import annotations
@@ -14,7 +15,13 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
+from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from inlite_ble.cloud import (
@@ -28,9 +35,17 @@ from inlite_ble.cloud import (
 from .const import (
     CONF_GARDEN_ID,
     CONF_GARDEN_NAME,
+    CONF_IDLE_DISCONNECT,
     CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
     CONF_TRANSFORMERS,
+    DEFAULT_IDLE_DISCONNECT_SECONDS,
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    MAX_IDLE_DISCONNECT_SECONDS,
+    MAX_SCAN_INTERVAL,
+    MIN_IDLE_DISCONNECT_SECONDS,
+    MIN_SCAN_INTERVAL,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,6 +62,12 @@ class InliteConfigFlow(ConfigFlow, domain=DOMAIN):
         self._gardens: list[Garden] = []
         self._discovery_info: BluetoothServiceInfoBleak | None = None
         self._reauth_entry: ConfigEntry | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> InliteOptionsFlow:
+        """Get the options flow handler."""
+        return InliteOptionsFlow(config_entry)
 
     # ------------------------------------------------------------------
     # Bluetooth discovery entry point
@@ -224,4 +245,49 @@ class InliteConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reauth_confirm",
             description_placeholders={"email": self._email or ""},
+        )
+
+
+class InliteOptionsFlow(OptionsFlow):
+    """Handle in-lite options."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize options flow."""
+        self._config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        current_scan = self._config_entry.options.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
+        current_idle = self._config_entry.options.get(
+            CONF_IDLE_DISCONNECT, DEFAULT_IDLE_DISCONNECT_SECONDS
+        )
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL, default=current_scan
+                    ): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(min=MIN_SCAN_INTERVAL, max=MAX_SCAN_INTERVAL),
+                    ),
+                    vol.Required(
+                        CONF_IDLE_DISCONNECT, default=current_idle
+                    ): vol.All(
+                        vol.Coerce(int),
+                        vol.Range(
+                            min=MIN_IDLE_DISCONNECT_SECONDS,
+                            max=MAX_IDLE_DISCONNECT_SECONDS,
+                        ),
+                    ),
+                }
+            ),
         )

--- a/custom_components/inlite/const.py
+++ b/custom_components/inlite/const.py
@@ -10,11 +10,19 @@ CONF_GARDEN_NAME = "garden_name"
 CONF_PASSWORD = "password"
 CONF_TRANSFORMERS = "transformers"
 
-# Coordinator
-DEFAULT_SCAN_INTERVAL = 120  # seconds between BLE state polls
+# Options flow keys
+CONF_SCAN_INTERVAL = "scan_interval"
+CONF_IDLE_DISCONNECT = "idle_disconnect"
+
+# Coordinator defaults
+DEFAULT_SCAN_INTERVAL = 30  # seconds between BLE state polls
+MIN_SCAN_INTERVAL = 10
+MAX_SCAN_INTERVAL = 300
 
 # BLE
 BLE_LOCAL_NAME = "inlitebt"
 
-# Connection management
-BLE_IDLE_DISCONNECT_SECONDS = 300  # disconnect after 5 min idle
+# Connection management defaults
+DEFAULT_IDLE_DISCONNECT_SECONDS = 3600  # 1 hour — keeps connection alive for OOB updates
+MIN_IDLE_DISCONNECT_SECONDS = 60
+MAX_IDLE_DISCONNECT_SECONDS = 7200

--- a/custom_components/inlite/coordinator.py
+++ b/custom_components/inlite/coordinator.py
@@ -3,6 +3,7 @@
 Manages a persistent BLE connection with a connection lock to serialize
 all hub communication. Connects once and queries all hubs before disconnecting.
 Includes retry-with-reconnect for both commands and polling.
+Receives OOB broadcast notifications for real-time state updates.
 """
 
 from __future__ import annotations
@@ -10,7 +11,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import timedelta
-from typing import Any
 
 from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 from homeassistant.components import bluetooth
@@ -21,10 +21,12 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from inlite_ble.hub import InliteHub, ZoneState
 
 from .const import (
-    BLE_IDLE_DISCONNECT_SECONDS,
     BLE_LOCAL_NAME,
+    CONF_IDLE_DISCONNECT,
     CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
     CONF_TRANSFORMERS,
+    DEFAULT_IDLE_DISCONNECT_SECONDS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
@@ -45,16 +47,18 @@ class InliteCoordinator(DataUpdateCoordinator[dict[int, dict[int, ZoneState]]]):
     - Single BLE connection shared across all hubs (they share a gateway)
     - Retry with disconnect-reconnect on command/poll failure
     - Cached BLE device reference from advertisement callbacks
+    - OOB broadcast callback for real-time state push from the hub
     - Proper cleanup on unload
     """
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize coordinator."""
+        scan_interval = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(seconds=DEFAULT_SCAN_INTERVAL),
+            update_interval=timedelta(seconds=scan_interval),
         )
         self.entry = entry
         self._hubs: dict[int, InliteHub] = {}
@@ -62,6 +66,9 @@ class InliteCoordinator(DataUpdateCoordinator[dict[int, dict[int, ZoneState]]]):
         self._ble_lock = asyncio.Lock()
         self._disconnect_timer: asyncio.TimerHandle | None = None
         self._ble_service_info: bluetooth.BluetoothServiceInfoBleak | None = None
+        self._idle_disconnect_seconds = entry.options.get(
+            CONF_IDLE_DISCONNECT, DEFAULT_IDLE_DISCONNECT_SECONDS
+        )
 
         password = entry.data[CONF_PASSWORD]
         for tx_data in entry.data[CONF_TRANSFORMERS]:
@@ -69,6 +76,7 @@ class InliteCoordinator(DataUpdateCoordinator[dict[int, dict[int, ZoneState]]]):
             hub = InliteHub(
                 device_id=device_id,
                 passphrase=password,
+                on_state_update=self._handle_oob_state_update,
             )
             self._hubs[device_id] = hub
 
@@ -90,6 +98,23 @@ class InliteCoordinator(DataUpdateCoordinator[dict[int, dict[int, ZoneState]]]):
         (critical for ESPHome BLE proxy failover).
         """
         self._ble_service_info = service_info
+
+    def _handle_oob_state_update(self) -> None:
+        """Handle an OOB broadcast notification from a hub.
+
+        Called (on the event loop via call_soon_threadsafe) when the hub receives
+        a state change broadcast (e.g., physical button press, timer trigger).
+        Builds the full state dict from all hubs and pushes it to HA entities.
+        """
+        all_states: dict[int, dict[int, ZoneState]] = {}
+        for device_id, hub in self._hubs.items():
+            if hub.zone_states:
+                all_states[device_id] = hub.zone_states
+
+        if all_states:
+            _LOGGER.debug("OOB state update received, pushing to HA entities")
+            self._available = True
+            self.async_set_updated_data(all_states)
 
     def _find_ble_device(self) -> bluetooth.BluetoothServiceInfoBleak | None:
         """Find the in-lite hub, preferring the cached reference."""
@@ -125,7 +150,7 @@ class InliteCoordinator(DataUpdateCoordinator[dict[int, dict[int, ZoneState]]]):
         """Schedule a disconnect after the idle timeout."""
         self._cancel_idle_disconnect()
         self._disconnect_timer = self.hass.loop.call_later(
-            BLE_IDLE_DISCONNECT_SECONDS,
+            self._idle_disconnect_seconds,
             lambda: self.hass.async_create_task(self._idle_disconnect()),
         )
 

--- a/custom_components/inlite/lib/inlite_ble/hub.py
+++ b/custom_components/inlite/lib/inlite_ble/hub.py
@@ -81,6 +81,7 @@ class InliteHub:
         device_id: The hub's mesh device ID (from cloud API transformers[].deviceId)
         passphrase: The garden's network passphrase (from cloud API gardens[].password)
         ble_address: BLE device address or name (e.g., 'inlitebt' or a MAC/UUID)
+        on_state_update: Optional callback invoked when OOB broadcast updates zone states.
     """
 
     def __init__(
@@ -88,6 +89,7 @@ class InliteHub:
         device_id: int,
         passphrase: str,
         ble_address: str = "inlitebt",
+        on_state_update: Callable[[], None] | None = None,
     ) -> None:
         self._device_id = device_id
         self._crypto = CsrMeshCrypto(passphrase)
@@ -100,6 +102,7 @@ class InliteHub:
         self._last_stream_data = b""
         self._zone_states: dict[int, ZoneState] = {}
         self._notification_callback: Callable[[dict[str, Any]], None] | None = None
+        self._on_state_update = on_state_update
 
     @property
     def device_id(self) -> int:
@@ -222,23 +225,31 @@ class InliteHub:
 
         data = payload[3:]
         i = 0
+        changed = False
         while i + 3 < len(data):
             outlet_id = data[i]
             output_mode = data[i + 1]
             output_state = data[i + 2]
             # data[i + 3] = rtcTimer
             if outlet_id in self._zone_states:
-                self._zone_states[outlet_id].output_mode = output_mode
-                self._zone_states[outlet_id].output_state = output_state
+                old = self._zone_states[outlet_id]
+                if old.output_mode != output_mode or old.output_state != output_state:
+                    changed = True
+                old.output_mode = output_mode
+                old.output_state = output_state
             else:
                 self._zone_states[outlet_id] = ZoneState(
                     output_id=outlet_id,
                     output_mode=output_mode,
                     output_state=output_state,
                 )
+                changed = True
             _LOGGER.debug("OOB update: zone %d mode=0x%02X state=0x%02X",
                           outlet_id, output_mode, output_state)
             i += 4
+
+        if changed and self._on_state_update is not None:
+            self._on_state_update()
 
     async def _write(self, packet: bytes) -> None:
         """Write an encrypted packet to the hub."""

--- a/custom_components/inlite/strings.json
+++ b/custom_components/inlite/strings.json
@@ -41,5 +41,17 @@
             "already_configured": "This garden is already configured.",
             "reauth_successful": "Re-authentication successful."
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "title": "in-lite Options",
+                "description": "Configure polling and connection behavior. A longer idle disconnect keeps the BLE connection alive to receive real-time state updates from the hub (e.g., physical button presses).",
+                "data": {
+                    "scan_interval": "Poll interval (seconds)",
+                    "idle_disconnect": "Idle disconnect timeout (seconds)"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #5 — Physical smarthub state changes (button presses, timer triggers) are now reflected in Home Assistant in near real-time.

## Root Cause

The hub already parsed OOB (Out-Of-Band) broadcast notifications internally, but:
1. The coordinator was never notified of these state changes
2. The BLE connection disconnected after 5 minutes, making it impossible to receive broadcasts

## Changes

| File | Change |
|------|--------|
| `hub.py` | Added `on_state_update` callback; `_parse_oob_broadcast` now detects changes and fires it |
| `coordinator.py` | Registers callback → pushes state to HA entities via `async_set_updated_data` |
| `const.py` | Poll interval 120s→30s, idle disconnect 5min→1hr (both configurable) |
| `config_flow.py` | Added `OptionsFlow` for UI-configurable poll interval & idle disconnect |
| `__init__.py` | Options update listener triggers integration reload |
| `strings.json` | UI labels for new options |

## How It Works

1. **While connected**: Hub sends OOB broadcast when zones change → callback fires → HA entities update immediately (~0s latency)
2. **While disconnected**: Next poll cycle (every 30s) picks up the change
3. **Configurable**: Users can tune poll interval (10-300s) and idle disconnect (60-7200s) via integration options

## Trade-off: High Idle Disconnect

The 1-hour default keeps the BLE connection alive to receive push notifications. Downside: occupies one BLE connection slot on the ESP32 proxy (typically 3-7 available). Users with many BLE devices can reduce it via the options UI.

## Testing

All 37 existing tests pass. No new lint issues introduced.
